### PR TITLE
feat: Add highlighting for HTTP methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ const spawn = require('child_process').spawn
 const highlight = require('cli-highlight').highlight
 const colors = require('chalk')
 const argv = require('minimist')(process.argv.slice(2), {stopEarly: true})
-console.log(argv) // Optional: Keep or remove for debugging
 const cmd = argv._.shift()
 
 // Signal handlers
@@ -77,6 +76,13 @@ function highlightAndPrint(dataString) {
 		// const h = highlight(match, {language: 'json', ignoreIllegals: true})
 		return colors.redBright(match)
 	})
+
+	// HTTP method highlighting
+	const httpMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];
+	const httpMethodRegex = new RegExp(` (${httpMethods.join('|')}) `, 'g');
+	chunk = chunk.replace(httpMethodRegex, function (match) {
+		return ' ' + colors.underline.bold(match.trim()) + ' ';
+	});
 
 	// eslint-disable-next-line no-console
 	console.log(chunk)

--- a/test_logs.txt
+++ b/test_logs.txt
@@ -14,3 +14,21 @@ URL with trailing question mark: /api/config?
 URL with multiple ampersands: /api/search?type=product&query=widget&sort=price&filter=available
 URL with empty value: /api/check?param=&another=value
 URL with query param at end of line: /api/fetch?id=100
+
+# HTTP Method Tests
+This is a GET request.
+Another line with POST here.
+Request with PUT method.
+And one for DELETE operation.
+Let's PATCH this.
+Sending a HEAD request.
+Check OPTIONS for this resource.
+
+# Negative tests for HTTP Methods
+This is a get request.
+This is aPOSTrequest.
+This is a PUTT request.
+This is a RequestMethodNotHandled request.
+This is a GETT request.
+No space beforeGET.
+No space afterPOST .


### PR DESCRIPTION
This commit introduces highlighting for common HTTP methods (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS) in log lines.

- Methods are detected if they are uppercase and surrounded by single spaces (e.g., ' PUT ').
- Highlighting is done using `chalk.underline.bold` to differentiate from other log level highlights.
- Added relevant test cases to `test_logs.txt` to cover positive and negative scenarios.
- Removed a debug `console.log(argv)` from the script.