### PR TITLE
feat: Implement UuidHighlighter

### DIFF
--- a/lib/highlighters/UuidHighlighter.js
+++ b/lib/highlighters/UuidHighlighter.js
@@ -1,25 +1,25 @@
 class UuidHighlighter {
-  /**
-   * Checks if the given text represents a valid UUID.
-   * A UUID is a 36-character string (including 4 hyphens) of the form
-   * xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx where x is a hexadecimal digit.
-   *
-   * @param {string} text The text to check.
-   * @returns {boolean} True if the text is a UUID, false otherwise.
-   */
-  isUuid(text) {
-    if (text === null || text === undefined || typeof text !== 'string') {
-      return false;
-    }
+	/**
+	 * Checks if the given text represents a valid UUID.
+	 * A UUID is a 36-character string (including 4 hyphens) of the form
+	 * xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx where x is a hexadecimal digit.
+	 *
+	 * @param {string} text The text to check.
+	 * @returns {boolean} True if the text is a UUID, false otherwise.
+	 */
+	isUuid(text) {
+		if (text === null || text === undefined || typeof text !== 'string') {
+			return false
+		}
 
-    const trimmedText = text.trim();
-    if (trimmedText.length !== 36) {
-      return false;
-    }
+		const trimmedText = text.trim()
+		if (trimmedText.length !== 36) {
+			return false
+		}
 
-    const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-    return uuidRegex.test(trimmedText);
-  }
+		const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+		return uuidRegex.test(trimmedText)
+	}
 }
 
-module.exports = UuidHighlighter;
+module.exports = UuidHighlighter

--- a/lib/highlighters/UuidHighlighter.js
+++ b/lib/highlighters/UuidHighlighter.js
@@ -1,0 +1,25 @@
+class UuidHighlighter {
+  /**
+   * Checks if the given text represents a valid UUID.
+   * A UUID is a 36-character string (including 4 hyphens) of the form
+   * xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx where x is a hexadecimal digit.
+   *
+   * @param {string} text The text to check.
+   * @returns {boolean} True if the text is a UUID, false otherwise.
+   */
+  isUuid(text) {
+    if (text === null || text === undefined || typeof text !== 'string') {
+      return false;
+    }
+
+    const trimmedText = text.trim();
+    if (trimmedText.length !== 36) {
+      return false;
+    }
+
+    const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+    return uuidRegex.test(trimmedText);
+  }
+}
+
+module.exports = UuidHighlighter;

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,11 @@ const { highlightDateTime } = require('./highlighters/dateTime')
 const { highlightLogLevel } = require('./highlighters/logLevel')
 const { highlightHttpMethod } = require('./highlighters/httpMethod') // Import the HttpMethod highlighter
 const PathHighlighter = require('./highlighters/PathHighlighter') // Import the PathHighlighter class
+const UuidHighlighter = require('./highlighters/UuidHighlighter'); // Import the UuidHighlighter class
 
 // Define PathHighlighter instance and highlightPath function at the top level
 const pathHighlighterInstance = new PathHighlighter()
+const uuidHighlighterInstance = new UuidHighlighter();
 function highlightPath(dataString) {
 	// Check if the entire dataString is a path.
 	if (pathHighlighterInstance.isPath(dataString.trim())) { // Trim to avoid issues with trailing newlines etc.
@@ -19,6 +21,16 @@ function highlightPath(dataString) {
 		return `\x1b[1m${dataString}\x1b[0m`
 	}
 	return dataString
+}
+
+function highlightUuid(dataString) {
+    // Check if the entire dataString is a UUID.
+    if (uuidHighlighterInstance.isUuid(dataString.trim())) { // Trim to avoid issues with trailing newlines etc.
+        // Apply some form of highlighting. Using ANSI bold as an example.
+        // [1m makes text bold, [0m resets it.
+        return `\x1b[1m${dataString}\x1b[0m`;
+    }
+    return dataString;
 }
 
 const argv = require('minimist')(process.argv.slice(2), {stopEarly: true})
@@ -52,6 +64,9 @@ function highlightAndPrint(dataString) {
 
 	// Use the new Path highlighter (now defined at top level)
 	chunk = highlightPath(chunk)
+
+	// Use the new Uuid highlighter
+	chunk = highlightUuid(chunk);
 
 	// eslint-disable-next-line no-console
 	console.log(chunk)
@@ -98,6 +113,7 @@ module.exports = [
 	highlightDateTime, // Already imported: const { highlightDateTime } = require('./highlighters/dateTime');
 	highlightLogLevel, // Already imported: const { highlightLogLevel } = require('./highlighters/logLevel');
 	highlightHttpMethod, // Already imported: const { highlightHttpMethod } = require('./highlighters/httpMethod');
-	highlightPath // Now defined at the top level and used by highlightAndPrint
+	highlightPath, // Now defined at the top level and used by highlightAndPrint
+	highlightUuid // Add the new Uuid highlighter function
 ]
 // npm i minimist

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,11 +8,11 @@ const { highlightDateTime } = require('./highlighters/dateTime')
 const { highlightLogLevel } = require('./highlighters/logLevel')
 const { highlightHttpMethod } = require('./highlighters/httpMethod') // Import the HttpMethod highlighter
 const PathHighlighter = require('./highlighters/PathHighlighter') // Import the PathHighlighter class
-const UuidHighlighter = require('./highlighters/UuidHighlighter'); // Import the UuidHighlighter class
+const UuidHighlighter = require('./highlighters/UuidHighlighter') // Import the UuidHighlighter class
 
 // Define PathHighlighter instance and highlightPath function at the top level
 const pathHighlighterInstance = new PathHighlighter()
-const uuidHighlighterInstance = new UuidHighlighter();
+const uuidHighlighterInstance = new UuidHighlighter()
 function highlightPath(dataString) {
 	// Check if the entire dataString is a path.
 	if (pathHighlighterInstance.isPath(dataString.trim())) { // Trim to avoid issues with trailing newlines etc.
@@ -24,13 +24,13 @@ function highlightPath(dataString) {
 }
 
 function highlightUuid(dataString) {
-    // Check if the entire dataString is a UUID.
-    if (uuidHighlighterInstance.isUuid(dataString.trim())) { // Trim to avoid issues with trailing newlines etc.
-        // Apply some form of highlighting. Using ANSI bold as an example.
-        // [1m makes text bold, [0m resets it.
-        return `\x1b[1m${dataString}\x1b[0m`;
-    }
-    return dataString;
+	// Check if the entire dataString is a UUID.
+	if (uuidHighlighterInstance.isUuid(dataString.trim())) { // Trim to avoid issues with trailing newlines etc.
+		// Apply some form of highlighting. Using ANSI bold as an example.
+		// [1m makes text bold, [0m resets it.
+		return `\x1b[1m${dataString}\x1b[0m`
+	}
+	return dataString
 }
 
 const argv = require('minimist')(process.argv.slice(2), {stopEarly: true})
@@ -66,7 +66,7 @@ function highlightAndPrint(dataString) {
 	chunk = highlightPath(chunk)
 
 	// Use the new Uuid highlighter
-	chunk = highlightUuid(chunk);
+	chunk = highlightUuid(chunk)
 
 	// eslint-disable-next-line no-console
 	console.log(chunk)

--- a/tests/highlighters/UuidHighlighter.test.js
+++ b/tests/highlighters/UuidHighlighter.test.js
@@ -1,73 +1,73 @@
-const UuidHighlighter = require('../../lib/highlighters/UuidHighlighter');
+const UuidHighlighter = require('../../lib/highlighters/UuidHighlighter')
 
 describe('UuidHighlighter', () => {
-  let highlighter;
+	let highlighter
 
-  beforeAll(() => {
-    highlighter = new UuidHighlighter();
-  });
+	beforeAll(() => {
+		highlighter = new UuidHighlighter()
+	})
 
-  describe('Valid UUIDs', () => {
-    it('should identify lowercase UUIDs', () => {
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789')).toBe(true);
-    });
+	describe('Valid UUIDs', () => {
+		it('should identify lowercase UUIDs', () => {
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789')).toBe(true)
+		})
 
-    it('should identify uppercase UUIDs', () => {
-      expect(highlighter.isUuid('ABCDEF01-2345-6789-ABCD-EF0123456789')).toBe(true);
-    });
+		it('should identify uppercase UUIDs', () => {
+			expect(highlighter.isUuid('ABCDEF01-2345-6789-ABCD-EF0123456789')).toBe(true)
+		})
 
-    it('should identify mixed-case UUIDs', () => {
-      expect(highlighter.isUuid('AbCdEf01-2345-6789-AbCd-Ef0123456789')).toBe(true);
-    });
+		it('should identify mixed-case UUIDs', () => {
+			expect(highlighter.isUuid('AbCdEf01-2345-6789-AbCd-Ef0123456789')).toBe(true)
+		})
 
-    it('should identify UUIDs with numbers', () => {
-      expect(highlighter.isUuid('12345678-1234-1234-1234-123456789012')).toBe(true);
-    });
-  });
+		it('should identify UUIDs with numbers', () => {
+			expect(highlighter.isUuid('12345678-1234-1234-1234-123456789012')).toBe(true)
+		})
+	})
 
-  describe('Invalid UUIDs', () => {
-    it('should reject strings with incorrect length', () => {
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678')).toBe(false); // Too short
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef01234567890')).toBe(false); // Too long
-    });
+	describe('Invalid UUIDs', () => {
+		it('should reject strings with incorrect length', () => {
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678')).toBe(false) // Too short
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef01234567890')).toBe(false) // Too long
+		})
 
-    it('should reject strings with incorrect format (hyphen placement)', () => {
-      expect(highlighter.isUuid('abcdef012-345-6789-abcd-ef0123456789')).toBe(false);
-      expect(highlighter.isUuid('abcdef01-23456-789-abcd-ef0123456789')).toBe(false);
-      expect(highlighter.isUuid('abcdef01-2345-6789ab-cd-ef0123456789')).toBe(false);
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd--ef0123456789')).toBe(false);
-    });
+		it('should reject strings with incorrect format (hyphen placement)', () => {
+			expect(highlighter.isUuid('abcdef012-345-6789-abcd-ef0123456789')).toBe(false)
+			expect(highlighter.isUuid('abcdef01-23456-789-abcd-ef0123456789')).toBe(false)
+			expect(highlighter.isUuid('abcdef01-2345-6789ab-cd-ef0123456789')).toBe(false)
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd--ef0123456789')).toBe(false)
+		})
 
-    it('should reject strings with non-hexadecimal characters', () => {
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678g')).toBe(false); // 'g' is not hex
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678Z')).toBe(false); // 'Z' is not hex
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678!')).toBe(false); // '!' is not hex
-    });
+		it('should reject strings with non-hexadecimal characters', () => {
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678g')).toBe(false) // 'g' is not hex
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678Z')).toBe(false) // 'Z' is not hex
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678!')).toBe(false) // '!' is not hex
+		})
 
-    it('should reject strings that are almost UUIDs but have extra characters', () => {
-      expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(false); // Leading space (handled by trim in method)
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(false); // Trailing space (handled by trim in method)
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789\n')).toBe(false); // Trailing newline
-    });
-  });
+		it('should reject strings that are almost UUIDs but have extra characters', () => {
+			expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(false) // Leading space (handled by trim in method)
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(false) // Trailing space (handled by trim in method)
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789\n')).toBe(false) // Trailing newline
+		})
+	})
 
-  describe('Edge cases', () => {
-    it('should handle null, undefined, and empty/blank strings', () => {
-      expect(highlighter.isUuid(null)).toBe(false);
-      expect(highlighter.isUuid(undefined)).toBe(false);
-      expect(highlighter.isUuid('')).toBe(false);
-      expect(highlighter.isUuid('   ')).toBe(false); // Only spaces
-    });
+	describe('Edge cases', () => {
+		it('should handle null, undefined, and empty/blank strings', () => {
+			expect(highlighter.isUuid(null)).toBe(false)
+			expect(highlighter.isUuid(undefined)).toBe(false)
+			expect(highlighter.isUuid('')).toBe(false)
+			expect(highlighter.isUuid('   ')).toBe(false) // Only spaces
+		})
 
-    it('should handle strings that are only hyphens', () => {
-      expect(highlighter.isUuid('--------')).toBe(false);
-      expect(highlighter.isUuid('------------------------------------')).toBe(false);
-    });
+		it('should handle strings that are only hyphens', () => {
+			expect(highlighter.isUuid('--------')).toBe(false)
+			expect(highlighter.isUuid('------------------------------------')).toBe(false)
+		})
 
-     it('should correctly handle trimmed valid UUIDs with leading/trailing spaces', () => {
-      expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(true);
-      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(true);
-      expect(highlighter.isUuid('  abcdef01-2345-6789-abcd-ef0123456789  ')).toBe(true);
-    });
-  });
-});
+		it('should correctly handle trimmed valid UUIDs with leading/trailing spaces', () => {
+			expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(true)
+			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(true)
+			expect(highlighter.isUuid('  abcdef01-2345-6789-abcd-ef0123456789  ')).toBe(true)
+		})
+	})
+})

--- a/tests/highlighters/UuidHighlighter.test.js
+++ b/tests/highlighters/UuidHighlighter.test.js
@@ -1,0 +1,73 @@
+const UuidHighlighter = require('../../lib/highlighters/UuidHighlighter');
+
+describe('UuidHighlighter', () => {
+  let highlighter;
+
+  beforeAll(() => {
+    highlighter = new UuidHighlighter();
+  });
+
+  describe('Valid UUIDs', () => {
+    it('should identify lowercase UUIDs', () => {
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789')).toBe(true);
+    });
+
+    it('should identify uppercase UUIDs', () => {
+      expect(highlighter.isUuid('ABCDEF01-2345-6789-ABCD-EF0123456789')).toBe(true);
+    });
+
+    it('should identify mixed-case UUIDs', () => {
+      expect(highlighter.isUuid('AbCdEf01-2345-6789-AbCd-Ef0123456789')).toBe(true);
+    });
+
+    it('should identify UUIDs with numbers', () => {
+      expect(highlighter.isUuid('12345678-1234-1234-1234-123456789012')).toBe(true);
+    });
+  });
+
+  describe('Invalid UUIDs', () => {
+    it('should reject strings with incorrect length', () => {
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678')).toBe(false); // Too short
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef01234567890')).toBe(false); // Too long
+    });
+
+    it('should reject strings with incorrect format (hyphen placement)', () => {
+      expect(highlighter.isUuid('abcdef012-345-6789-abcd-ef0123456789')).toBe(false);
+      expect(highlighter.isUuid('abcdef01-23456-789-abcd-ef0123456789')).toBe(false);
+      expect(highlighter.isUuid('abcdef01-2345-6789ab-cd-ef0123456789')).toBe(false);
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd--ef0123456789')).toBe(false);
+    });
+
+    it('should reject strings with non-hexadecimal characters', () => {
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678g')).toBe(false); // 'g' is not hex
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678Z')).toBe(false); // 'Z' is not hex
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef012345678!')).toBe(false); // '!' is not hex
+    });
+
+    it('should reject strings that are almost UUIDs but have extra characters', () => {
+      expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(false); // Leading space (handled by trim in method)
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(false); // Trailing space (handled by trim in method)
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789\n')).toBe(false); // Trailing newline
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle null, undefined, and empty/blank strings', () => {
+      expect(highlighter.isUuid(null)).toBe(false);
+      expect(highlighter.isUuid(undefined)).toBe(false);
+      expect(highlighter.isUuid('')).toBe(false);
+      expect(highlighter.isUuid('   ')).toBe(false); // Only spaces
+    });
+
+    it('should handle strings that are only hyphens', () => {
+      expect(highlighter.isUuid('--------')).toBe(false);
+      expect(highlighter.isUuid('------------------------------------')).toBe(false);
+    });
+
+     it('should correctly handle trimmed valid UUIDs with leading/trailing spaces', () => {
+      expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(true);
+      expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(true);
+      expect(highlighter.isUuid('  abcdef01-2345-6789-abcd-ef0123456789  ')).toBe(true);
+    });
+  });
+});

--- a/tests/highlighters/UuidHighlighter.test.js
+++ b/tests/highlighters/UuidHighlighter.test.js
@@ -45,9 +45,13 @@ describe('UuidHighlighter', () => {
 		})
 
 		it('should reject strings that are almost UUIDs but have extra characters', () => {
-			expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(false) // Leading space (handled by trim in method)
-			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(false) // Trailing space (handled by trim in method)
-			expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789\n')).toBe(false) // Trailing newline
+			// The following lines were removed as they incorrectly expected false.
+			// UUIDs with leading/trailing whitespace are handled by trim() in isUuid
+			// and should return true if the core string is a valid UUID.
+			// These cases are correctly tested in the "Edge cases" suite.
+			// expect(highlighter.isUuid(' abcdef01-2345-6789-abcd-ef0123456789')).toBe(false) // Leading space (handled by trim in method)
+			// expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789 ')).toBe(false) // Trailing space (handled by trim in method)
+			// expect(highlighter.isUuid('abcdef01-2345-6789-abcd-ef0123456789\n')).toBe(false) // Trailing newline
 		})
 	})
 


### PR DESCRIPTION
Adds a new UuidHighlighter class to detect and highlight UUID strings.

The UuidHighlighter:
- Identifies standard UUID format (e.g., xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
- Uses a regular expression for matching hexadecimal characters and hyphen placement.
- Handles leading/trailing whitespace by trimming the input string.

The changes include:
- `lib/highlighters/UuidHighlighter.js`: The new highlighter class.
- `tests/highlighters/UuidHighlighter.test.js`: Unit tests for the highlighter, covering valid, invalid, and edge case UUIDs.
- `lib/index.js`: Updated to import, instantiate, and use the UuidHighlighter in the main highlighting pipeline. The `highlightUuid` function is also added to `module.exports`.